### PR TITLE
View team collections

### DIFF
--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="show">
         <tabs style="m-4" :id="'collections_tab'" v-on:tab-changed="updateCollectionsType">
             <tab
                 :id="'my-collections'"
@@ -58,7 +58,8 @@ var teamCollectionsTab = document.getElementById('team-collections')
 
 export default {
     props: {
-        collectionsType: Object
+        collectionsType: Object,
+        show: Boolean
     },
     apollo: {    
         myTeams: {

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -32,6 +32,7 @@
                                 class="icon"
                                 @click="
                                     collectionsType.selectedTeam = team;
+                                    $emit('collectionsType-updated')
                                 "
                                 v-close-popover
                                 >
@@ -84,6 +85,8 @@ export default {
     methods: {
         updateCollectionsType(tabID) {
             this.collectionsType.type = tabID
+            this.$emit('collectionsType-updated');
+
         }
     }
 }

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -1,0 +1,90 @@
+<template>
+    <div>
+        <tabs style="m-4" :id="'collections_tab'" v-on:tab-changed="updateCollectionsType">
+            <tab
+                :id="'my-collections'"
+                :label="'My Collections'"
+                :selected="true"
+            >
+            </tab>
+            <tab
+                :id="'team-collections'"
+                :label="'Team Collections'"
+                :selected="false"
+            >
+                <ul>
+                    <li>
+                        <label for="select_team"> Select Team: </label>
+                        <span class="select-wrapper">
+                        <v-popover>
+                            <input
+                            id="team"
+                            class="team"
+                            v-model="selectedTeam.name"
+                            autofocus
+                            />
+                            <template slot="popover">
+                            <div
+                                v-for="(team, index) in myTeams"
+                                :key="`method-${index}`"
+                            >
+                                <button
+                                class="icon"
+                                @click="
+                                    collectionsType.selectedTeam = team;
+                                "
+                                v-close-popover
+                                >
+                                {{ team.name }}
+                                </button>
+                            </div>
+                            </template>
+                        </v-popover>
+                        </span>
+                    </li>
+                </ul>
+            </tab>
+        </tabs>
+
+    </div>
+</template>
+
+<script>
+import tabs from '../ui/tabs';
+import gql from "graphql-tag"
+
+var teamCollectionsTab = document.getElementById('team-collections')
+
+export default {
+    props: {
+        collectionsType: Object
+    },
+    apollo: {    
+        myTeams: {
+            query: gql`
+                query GetMyTeams {
+                    myTeams {
+                        id
+                        name
+                    }
+                }
+            `,
+            pollInterval: 10000,
+        }
+    },
+    computed: {
+        selectedTeam() {
+            if(this.myTeams == null) return {name: 'Loading'}
+            if(this.collectionsType.selectedTeam == null) {
+                this.collectionsType.selectedTeam = this.myTeams[0]
+            }
+            return this.collectionsType.selectedTeam
+        },
+    },
+    methods: {
+        updateCollectionsType(tabID) {
+            this.collectionsType.type = tabID
+        }
+    }
+}
+</script>

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -79,6 +79,7 @@ export default {
             if(this.myTeams == null) return {name: 'Loading'}
             if(this.collectionsType.selectedTeam == null) {
                 this.collectionsType.selectedTeam = this.myTeams[0]
+                this.$emit('collectionsType-updated');
             }
             return this.collectionsType.selectedTeam
         },

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -16,31 +16,21 @@
                     <li>
                         <label for="select_team"> Select Team: </label>
                         <span class="select-wrapper">
-                        <v-popover>
-                            <input
+                            <select 
+                            type="text" 
                             id="team"
                             class="team"
-                            v-model="selectedTeam.name"
+                            v-model="selectedTeam"
                             autofocus
-                            />
-                            <template slot="popover">
-                            <div
-                                v-for="(team, index) in myTeams"
-                                :key="`method-${index}`"
                             >
-                                <button
-                                class="icon"
-                                @click="
-                                    collectionsType.selectedTeam = team;
-                                    $emit('collectionsType-updated')
-                                "
-                                v-close-popover
+                                <option
+                                v-for="(team, index) in myTeams"
+                                :key="index"
+                                :value="team"
                                 >
                                 {{ team.name }}
-                                </button>
-                            </div>
-                            </template>
-                        </v-popover>
+                                </option>
+                            </select>
                         </span>
                     </li>
                 </ul>

--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -13,7 +13,7 @@
         <i class="material-icons" v-show="!showChildren && !isFiltered">arrow_right</i>
         <i class="material-icons" v-show="showChildren || isFiltered">arrow_drop_down</i>
         <i class="material-icons">folder</i>
-        <span>{{ collection.name }}</span>
+        <span>{{ collection.name ? collection.name : collection.title }}</span>
       </button>
       <div>
         <button

--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -94,7 +94,7 @@
       </ul>
       <ul>
         <li
-          v-if="collection.folders.length === 0 && collection.requests.length === 0"
+          v-if="(collection.folders == undefined || collection.folders.length === 0) && (collection.requests == undefined || collection.requests.length === 0)"
           class="flex ml-8 border-l border-brdColor"
         >
           <p class="info">

--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -59,7 +59,7 @@
       <ul class="flex-col">
         <li
           v-for="(folder, index) in collection.folders"
-          :key="folder.name"
+          :key="(folder.name ? folder.name : folder.title)"
           class="ml-8 border-l border-brdColor"
         >
           <folder

--- a/components/collections/folder.vue
+++ b/components/collections/folder.vue
@@ -14,7 +14,7 @@
           <i class="material-icons" v-show="!showChildren && !isFiltered">arrow_right</i>
           <i class="material-icons" v-show="showChildren || isFiltered">arrow_drop_down</i>
           <i class="material-icons">folder_open</i>
-          <span>{{ folder.name }}</span>
+          <span>{{ (folder.name ? folder.name : folder.title) }}</span>
         </button>
       </div>
       <v-popover>

--- a/components/collections/folder.vue
+++ b/components/collections/folder.vue
@@ -80,6 +80,7 @@
             :folder-index="subFolderIndex"
             :collection-index="collectionIndex"
             :doc="doc"
+            :collectionsType="collectionsType"
             :folder-path="`${folderPath}/${subFolderIndex}`"
             @add-folder="$emit('add-folder', $event)"
             @edit-folder="$emit('edit-folder', $event)"
@@ -104,6 +105,7 @@
 
 <script>
 import { fb } from "~/helpers/fb"
+import gql from "graphql-tag"
 
 export default {
   name: "folder",
@@ -114,6 +116,7 @@ export default {
     folderPath: String,
     doc: Boolean,
     isFiltered: Boolean,
+    collectionsType: Object
   },
   data() {
     return {
@@ -132,6 +135,51 @@ export default {
     },
     toggleShowChildren() {
       this.showChildren = !this.showChildren
+      if(this.showChildren && this.collectionsType.type == 'team-collections' && this.folder.folders == undefined) {
+        console.log(this.folder)
+        this.$apollo.query({
+          query: gql`
+          query getCollectionChildren($collectionID: String!) {
+              collection(collectionID: $collectionID) {
+                  children {
+                      id
+                      title
+                  }
+              }
+          }
+          `,
+          variables: {
+            collectionID: this.folder.id
+          }
+        }).then((response) => {
+          console.log(response.data.collection.children)
+          this.$set(this.folder, 'folders', response.data.collection.children);
+        }).catch((error) => {
+          console.log(error);
+        });
+      }
+      if(this.showChildren && this.collectionsType.type == 'team-collections' && this.folder.requests == undefined) {
+        this.$apollo.query({
+          query: gql`
+          query getCollectionRequests($collectionID: String!) {
+              requestsInCollection(collectionID: $collectionID) {
+                  id
+                  title
+                  request
+              }
+          }
+          `,
+          variables: {
+            collectionID: this.folder.id
+          }
+        }).then((response) => {
+          console.log(response.data.requests)
+          this.$set(this.folder, 'requests', response.data.requests);
+        }).catch((error) => {
+          console.log(error);
+        });
+        
+      }
     },
     removeFolder() {
       this.$store.commit("postwoman/removeFolder", {

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -1,6 +1,9 @@
 <template>
   <pw-section class="yellow" :label="$t('collections')" ref="collections" no-legend>
-    <choose-collection-type :collectionsType="collectionsType" @collectionsType-updated="updateTeamCollections" />
+    <choose-collection-type 
+      :collectionsType="collectionsType" 
+      @collectionsType-updated="updateTeamCollections" 
+      :show="showTeamCollections" />
     <div class="show-on-large-screen">
       <input
         aria-label="Search"
@@ -133,6 +136,9 @@ export default {
     }
   },
   computed: {
+    showTeamCollections() {
+      return fb.currentUser !== null;
+    },
     collections() {
         return fb.currentUser !== null
           ? fb.currentCollections
@@ -203,7 +209,7 @@ export default {
           }
         }`,
         variables: {
-          teamID: this.collectionsType.selectedTeam.id,
+          teamID: this.collectionsType.selectedTeam ? this.collectionsType.selectedTeam.id: "",
         }          
       })).data.rootCollectionsOfTeam;
       console.log(this.teamCollections);

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -1,5 +1,6 @@
 <template>
   <pw-section class="yellow" :label="$t('collections')" ref="collections" no-legend>
+    <choose-collection-type :collectionsType="collectionsType" />
     <div class="show-on-large-screen">
       <input
         aria-label="Search"
@@ -87,6 +88,7 @@
 
 <script>
 import { fb } from "~/helpers/fb"
+import { gql, useQuery } from "graphql-tag"
 
 export default {
   props: {
@@ -109,18 +111,40 @@ export default {
       editingRequest: undefined,
       editingRequestIndex: undefined,
       filterText: "",
+      collectionsType: {
+        type: 'my-collections',
+        selectedTeam: undefined
+      }
     }
   },
   computed: {
     collections() {
-      return fb.currentUser !== null
-        ? fb.currentCollections
-        : this.$store.state.postwoman.collections
+      if(this.collectionsType.type == 'my-collections') {
+        console.log(fb.currentUser)
+        return fb.currentUser !== null
+          ? fb.currentCollections
+          : this.$store.state.postwoman.collections
+      } else {
+        console.log(this.collectionsType.selectedTeam.id)
+        console.log(this.collectionsType.selectedTeam.name)
+        try {
+        const collections = gql`
+                query rootCollectionsOfTeam {
+                  rootCollectionsOfTeam(teamID: ${this.collectionsType.selectedTeam.id}) {
+                    id
+                    title
+                  }
+                }
+            `
+        } catch(err) {
+          console.log(err)
+        }
+        return collections;
+      }
     },
     filteredCollections() {
-      const collections =
-        fb.currentUser !== null ? fb.currentCollections : this.$store.state.postwoman.collections
-
+      const collections = this.collections;
+      console.log(collections)
       if (!this.filterText) return collections
 
       const filterText = this.filterText.toLowerCase()

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -137,6 +137,9 @@ export default {
   },
   computed: {
     showTeamCollections() {
+      if(fb.currentUser == null) {
+        this.collectionsType.type = 'my-collections'
+      }
       return fb.currentUser !== null;
     },
     collections() {

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -143,9 +143,9 @@ export default {
       return fb.currentUser !== null;
     },
     collections() {
-        return fb.currentUser !== null
-          ? fb.currentCollections
-          : this.$store.state.postwoman.collections
+      return fb.currentUser !== null
+        ? fb.currentCollections
+        : this.$store.state.postwoman.collections
     },
     filteredCollections() {
       let collections = null;

--- a/components/ui/tabs.vue
+++ b/components/ui/tabs.vue
@@ -115,6 +115,7 @@ export default {
       this.tabs.forEach((tab) => {
         tab.isActive = tab.id == id
       })
+      this.$emit('tab-changed', id)
     },
   },
 }


### PR DESCRIPTION
**Changes:**
* Implemented integration of teams with collections in collections/index.vue 
* switching between My Collections and Team Collections and choosing team under Team Collections
* viewing team collections

**Remaining tasks:**
* Add, edit, delete and import collection/folders are still to be implemented for teams (coming in another PR).
* Viewing team requests has not been tested yet.
* collection fetch requests need to be of type "no-cache" (coming in another PR)
* All text is as strings and not in the $t("..") format.

**Preview:**

![Screenshot 2021-02-11 at 2 39 01 PM](https://user-images.githubusercontent.com/45964755/107618827-366e3680-6c78-11eb-8f7b-abe63ea808c0.png)
